### PR TITLE
TargetGroup connections to non-default ECS ports

### DIFF
--- a/packages/@aws-cdk/aws-ecs/lib/base/base-service.ts
+++ b/packages/@aws-cdk/aws-ecs/lib/base/base-service.ts
@@ -352,17 +352,13 @@ export abstract class BaseService extends Resource
 
     const container = this.taskDefinition._findContainerByHostPort(targetPort, Protocol.TCP);
     if (container === undefined) {
-      throw new Error("Could not find container that exposes requested host port");
+      throw new Error("Cannot attach a load balancer to an unmapped container port.");
     }
 
     const portMapping = container._findPortMapping(targetPort, Protocol.TCP);
-    if (portMapping === undefined) {
-      throw new Error("Could not find container port mapping for requested host port");
-    }
-
     return {
       targetGroupArn,
-      containerPort: portMapping.containerPort,
+      containerPort: portMapping!.containerPort,
       containerName: container.containerName,
     };
   }

--- a/packages/@aws-cdk/aws-ecs/lib/base/base-service.ts
+++ b/packages/@aws-cdk/aws-ecs/lib/base/base-service.ts
@@ -7,6 +7,7 @@ import cloudmap = require('@aws-cdk/aws-servicediscovery');
 import { Construct, Duration, IResolvable, IResource, Lazy, Resource, Stack } from '@aws-cdk/core';
 import { NetworkMode, TaskDefinition } from '../base/task-definition';
 import { ICluster } from '../cluster';
+import { Protocol } from '../container-definition';
 import { CfnService } from '../ecs.generated';
 import { ScalableTaskCount } from './scalable-task-count';
 
@@ -225,7 +226,7 @@ export abstract class BaseService extends Resource
 
     // Open up security groups. For dynamic port mapping, we won't know the port range
     // in advance so we need to open up all ports.
-    const port = this.taskDefinition.defaultContainer!.ingressPort;
+    const port = targetGroup.targetPort || this.taskDefinition.defaultContainer!.ingressPort;
     const portRange = port === 0 ? EPHEMERAL_PORT_RANGE : ec2.Port.tcp(port);
     targetGroup.registerConnectable(this, portRange);
 
@@ -327,11 +328,7 @@ export abstract class BaseService extends Resource
       throw new Error("Cannot use a load balancer if NetworkMode is None. Use Bridge, Host or AwsVpc instead.");
     }
 
-    this.loadBalancers.push({
-      targetGroupArn: targetGroup.targetGroupArn,
-      containerName: this.taskDefinition.defaultContainer!.containerName,
-      containerPort: this.taskDefinition.defaultContainer!.containerPort,
-    });
+    this.loadBalancers.push(this.makeLoadBalancerProperty(targetGroup.targetGroupArn, targetGroup.targetPort));
 
     // Service creation can only happen after the load balancer has
     // been associated with our target group(s), so add ordering dependency.
@@ -339,6 +336,35 @@ export abstract class BaseService extends Resource
 
     const targetType = this.taskDefinition.networkMode === NetworkMode.AWS_VPC ? elbv2.TargetType.IP : elbv2.TargetType.INSTANCE;
     return { targetType };
+  }
+
+  /**
+   * Generate a load balancer property given an optional host port
+   */
+  private makeLoadBalancerProperty(targetGroupArn: string, targetPort?: number): CfnService.LoadBalancerProperty {
+    if (targetPort === undefined) {
+      return {
+        targetGroupArn,
+        containerPort: this.taskDefinition.defaultContainer!.containerPort,
+        containerName: this.taskDefinition.defaultContainer!.containerName,
+      };
+    }
+
+    const container = this.taskDefinition._findContainerByHostPort(targetPort, Protocol.TCP);
+    if (container === undefined) {
+      throw new Error("Could not find container that exposes requested host port");
+    }
+
+    const portMapping = container._findPortMapping(targetPort, Protocol.TCP);
+    if (portMapping === undefined) {
+      throw new Error("Could not find container port mapping for requested host port");
+    }
+
+    return {
+      targetGroupArn,
+      containerPort: portMapping.containerPort,
+      containerName: container.containerName,
+    };
   }
 
   /**

--- a/packages/@aws-cdk/aws-ecs/lib/base/task-definition.ts
+++ b/packages/@aws-cdk/aws-ecs/lib/base/task-definition.ts
@@ -1,6 +1,6 @@
 import iam = require('@aws-cdk/aws-iam');
 import { Construct, IResource, Lazy, Resource } from '@aws-cdk/core';
-import { ContainerDefinition, ContainerDefinitionOptions } from '../container-definition';
+import { ContainerDefinition, ContainerDefinitionOptions, Protocol } from '../container-definition';
 import { CfnTaskDefinition } from '../ecs.generated';
 import { PlacementConstraint } from '../placement';
 
@@ -323,6 +323,19 @@ export class TaskDefinition extends TaskDefinitionBase {
     if (this.defaultContainer === undefined && container.essential) {
       this.defaultContainer = container;
     }
+  }
+
+  /**
+   * Returns the container that listens to a given host port if present.
+   * @internal
+   */
+  public _findContainerByHostPort(port: number, protocol: Protocol): ContainerDefinition | undefined {
+    for (const container of this.containers) {
+      if (container._findPortMapping(port, protocol) !== undefined) {
+        return container;
+      }
+    }
+    return undefined;
   }
 
   /**

--- a/packages/@aws-cdk/aws-ecs/lib/container-definition.ts
+++ b/packages/@aws-cdk/aws-ecs/lib/container-definition.ts
@@ -480,6 +480,21 @@ export class ContainerDefinition extends cdk.Construct {
   }
 
   /**
+   * Returns the container port for the requested host port if it exists
+   * @internal
+   */
+  public _findPortMapping(hostPort: number, protocol: Protocol): PortMapping | undefined {
+    for (const portMapping of this.portMappings) {
+      const p = portMapping.protocol || Protocol.TCP;
+      const h = portMapping.hostPort || portMapping.containerPort;
+      if (protocol === p && hostPort === h) {
+        return portMapping;
+      }
+    }
+    return undefined;
+  }
+
+  /**
    * Render this container definition to a CloudFormation object
    *
    * @param taskDefinition [disable-awslint:ref-via-interface] (made optional to avoid breaking change)

--- a/packages/@aws-cdk/aws-elasticloadbalancingv2/lib/alb/application-listener.ts
+++ b/packages/@aws-cdk/aws-elasticloadbalancingv2/lib/alb/application-listener.ts
@@ -201,7 +201,8 @@ export class ApplicationListener extends BaseListener implements IApplicationLis
       stickinessCookieDuration: props.stickinessCookieDuration,
       targetGroupName: props.targetGroupName,
       targets: props.targets,
-      vpc: this.loadBalancer.vpc
+      targetPort: props.targetPort,
+      vpc: this.loadBalancer.vpc,
     });
 
     this.addTargetGroups(id, {
@@ -500,6 +501,13 @@ export interface AddApplicationTargetsProps extends AddRuleProps {
    * @default Determined from protocol if known
    */
   readonly port?: number;
+
+  /**
+   * The port which the target group connects to
+   *
+   * @default Determined from target
+   */
+  readonly targetPort?: number;
 
   /**
    * The time period during which the load balancer sends a newly registered

--- a/packages/@aws-cdk/aws-elasticloadbalancingv2/lib/alb/application-listener.ts
+++ b/packages/@aws-cdk/aws-elasticloadbalancingv2/lib/alb/application-listener.ts
@@ -503,7 +503,7 @@ export interface AddApplicationTargetsProps extends AddRuleProps {
   readonly port?: number;
 
   /**
-   * The port which the target group connects to
+   * The port used to attach to targets.
    *
    * @default Determined from target
    */

--- a/packages/@aws-cdk/aws-elasticloadbalancingv2/lib/nlb/network-listener.ts
+++ b/packages/@aws-cdk/aws-elasticloadbalancingv2/lib/nlb/network-listener.ts
@@ -146,6 +146,7 @@ export class NetworkListener extends BaseListener implements INetworkListener {
       proxyProtocolV2: props.proxyProtocolV2,
       targetGroupName: props.targetGroupName,
       targets: props.targets,
+      targetPort: props.targetPort,
       vpc: this.loadBalancer.vpc,
     });
 
@@ -176,6 +177,13 @@ export interface AddNetworkTargetsProps {
    * @default Determined from protocol if known
    */
   readonly port: number;
+
+  /**
+   * The port which the target group connects to
+   *
+   * @default Determined from target
+   */
+  readonly targetPort?: number;
 
   /**
    * The targets to add to this target group.

--- a/packages/@aws-cdk/aws-elasticloadbalancingv2/lib/nlb/network-listener.ts
+++ b/packages/@aws-cdk/aws-elasticloadbalancingv2/lib/nlb/network-listener.ts
@@ -179,7 +179,7 @@ export interface AddNetworkTargetsProps {
   readonly port: number;
 
   /**
-   * The port which the target group connects to
+   * The port used to attach to targets.
    *
    * @default Determined from target
    */

--- a/packages/@aws-cdk/aws-elasticloadbalancingv2/lib/shared/base-target-group.ts
+++ b/packages/@aws-cdk/aws-elasticloadbalancingv2/lib/shared/base-target-group.ts
@@ -20,6 +20,15 @@ export interface BaseTargetGroupProps {
   readonly targetGroupName?: string;
 
   /**
+   * The target port to use for connection; uses the default port specified by the target
+   * if absent.  When specified, the target must expose the indicated port as a connection
+   * point.
+   *
+   * @default - Uses exposed port specified by the target
+   */
+  readonly targetPort?: number;
+
+  /**
    * The virtual private cloud (VPC).
    *
    * only if `TargetType` is `Ip` or `InstanceId`
@@ -151,6 +160,11 @@ export abstract class TargetGroupBase extends cdk.Construct implements ITargetGr
   public readonly targetGroupName: string;
 
   /**
+   * Port on the source that this target should listen to
+   */
+  public readonly targetPort?: number;
+
+  /**
    * ARNs of load balancers load balancing to this TargetGroup
    */
   public readonly targetGroupLoadBalancerArns: string[];
@@ -254,6 +268,7 @@ export abstract class TargetGroupBase extends cdk.Construct implements ITargetGr
     this.targetGroupFullName = this.resource.attrTargetGroupFullName;
     this.loadBalancerArns = this.resource.attrLoadBalancerArns.toString();
     this.targetGroupName = this.resource.attrTargetGroupName;
+    this.targetPort = baseProps.targetPort;
     this.defaultPort = additionalProps.port;
   }
 
@@ -347,6 +362,11 @@ export interface ITargetGroup extends cdk.IConstruct {
    * Return an object to depend on the listeners added to this target group
    */
   readonly loadBalancerAttached: cdk.IDependable;
+
+  /**
+   * Port target group is listening on
+   */
+  readonly targetPort?: number;
 }
 
 /**

--- a/packages/@aws-cdk/aws-elasticloadbalancingv2/lib/shared/base-target-group.ts
+++ b/packages/@aws-cdk/aws-elasticloadbalancingv2/lib/shared/base-target-group.ts
@@ -20,11 +20,10 @@ export interface BaseTargetGroupProps {
   readonly targetGroupName?: string;
 
   /**
-   * The target port to use for connection; uses the default port specified by the target
-   * if absent.  When specified, the target must expose the indicated port as a connection
-   * point.
+   * The target port to use for connection; when specified, the target must expose the indicated point
+   * explicitly.
    *
-   * @default - Uses exposed port specified by the target
+   * @default - Determined from target
    */
   readonly targetPort?: number;
 


### PR DESCRIPTION
Added ability to specify an explicit target port when attaching an application or network load balancer to an ec2 instance.  This allows attachment to secondary ports and sidecars running in EC2 instances or Fargate tasks.
